### PR TITLE
Fix SQL delete and autorole tuple bug

### DIFF
--- a/discord_bot_server/Arisu.py
+++ b/discord_bot_server/Arisu.py
@@ -54,7 +54,7 @@ async def on_guild_join(guild):
 async def on_guild_remove(guild):
     conn = sqlite3.connect("servers_info/main.db")
     cursor = conn.cursor()
-    cursor.execute("DELETE * FROM Guilds WHERE guild_id = ?", (guild.id,))
+    cursor.execute("DELETE FROM Guilds WHERE guild_id = ?", (guild.id,))
     conn.commit()
     conn.close()
 

--- a/discord_bot_server/cogs/autorole.py
+++ b/discord_bot_server/cogs/autorole.py
@@ -17,12 +17,17 @@ class AutoRole(commands.Cog):
         connection = sqlite3.connect("./servers_info/main.db")
         cursor = connection.cursor()
         
-        cursor.execute("SELECT auto_role_id FROM Auto_role WHERE guild_id = ?", (member.guild.id))
-        
-        auto_role_id = cursor.fetchone()
-           
-        if auto_role_id:
-            await member.add_roles(member.guild.get_role(auto_role_id))
+        cursor.execute(
+            "SELECT auto_role_id FROM Auto_role WHERE guild_id = ?",
+            (member.guild.id,)
+        )
+
+        result = cursor.fetchone()
+
+        if result and result[0]:
+            role = member.guild.get_role(result[0])
+            if role:
+                await member.add_roles(role)
         
     @app_commands.command(name="set_auto_role", description = "[ADMIN] Sets an automatic join role for this server.")
     @has_permissions(administrator=True)

--- a/discord_bot_server/update.sh
+++ b/discord_bot_server/update.sh
@@ -8,7 +8,7 @@ echo "Backing up local database..."
 cp -u servers_info/main.db servers_info/main.db.bak
 
 echo "Pulling latest code..."
-git git pull --no-rebase
+git pull --no-rebase
 
 echo "Starting bot..."
 exec python Arisu.py


### PR DESCRIPTION
## Summary
- fix invalid SQL syntax when removing a guild
- correctly fetch and apply auto roles
- fix typo in update script

## Testing
- `python -m py_compile discord_bot_server/Arisu.py discord_bot_server/cogs/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6851bb4218b4832bb05b3fe9dcf686f8