### PR TITLE
Fix FFMPEG typo in guide

### DIFF
--- a/discord_bot_server/Guide.txt
+++ b/discord_bot_server/Guide.txt
@@ -22,4 +22,4 @@ async def hello(interaction: discord.Integration):
     await interaction.response.send_message(f"{interaction.user.mention} Hello!", ephemeral = bool)
     #ephemeral = if only you can see the message
 
-SET UP FFMEPG ON YOUR SERVER TO USE THIS
+SET UP FFMPEG ON YOUR SERVER TO USE THIS


### PR DESCRIPTION
## Summary
- correct `FFMEPG` typo to `FFMPEG` in Guide

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68533a53bac0832ba16c11aa006e554e