### PR TITLE
Fix voice client connection

### DIFF
--- a/discord_bot_server/cogs/music.py
+++ b/discord_bot_server/cogs/music.py
@@ -58,25 +58,20 @@ class Music(commands.Cog):
             return
 
         try:
-            existing_vc = self.voice_clients.get(ctx.guild.id)
+            vc = ctx.voice_client
 
-            # Disconnect stale client if needed
-            if existing_vc:
-                if existing_vc.is_connected():
-                    if existing_vc.channel != ctx.author.voice.channel:
-                        await ctx.send(
-                            f"⚠️ I'm already playing in `{existing_vc.channel.name}`. "
-                            f"Join that channel to control me!"
-                        )
-                        return
-                else:
-                    try:
-                        await existing_vc.disconnect(force=True)
-                    except:
-                        pass
-
-            # Fresh connect
-            vc = await ctx.author.voice.channel.connect()
+            if vc:
+                # Already connected
+                if vc.channel != ctx.author.voice.channel:
+                    await ctx.send(
+                        f"⚠️ I'm already playing in `{vc.channel.name}`. "
+                        f"Join that channel to control me!"
+                    )
+                    return
+            else:
+                # No connection yet
+                vc = await ctx.author.voice.channel.connect()
+            # Track voice client
             self.voice_clients[ctx.guild.id] = vc
 
             # Queue logic


### PR DESCRIPTION
## Summary
- avoid reconnecting when already in a voice channel
- track the active voice connection

## Testing
- `python -m py_compile discord_bot_server/Arisu.py discord_bot_server/cogs/autorole.py discord_bot_server/cogs/music.py discord_bot_server/cogs/reactionroles.py discord_bot_server/cogs/test.py discord_bot_server/cogs/zerotwo.py`


------
https://chatgpt.com/codex/tasks/task_e_686c2b70bb98832b8eb1ab883b7e7537